### PR TITLE
upgrade nunjucks to 1.2.0 to support call tag and other feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "nunjucks": "~0.1.10"
+    "nunjucks": "~1.2.0"
   },
   "_id": "grunt-jinja-extend@0.3.0",
   "dist": {


### PR DESCRIPTION
The original nujucks is too old and use jinja1 syntax. Upgrade it to 1.2.0 to support more jinja2 syntxa. 😬 
